### PR TITLE
Convert HOMEASSISTANT_ENABLED env var to boolean

### DIFF
--- a/Application/configuration.py
+++ b/Application/configuration.py
@@ -44,7 +44,7 @@ class Configuration:
 
         self.NIGHT_MODE_BELOW = float(os.environ.get('NIGHT_MODE_BELOW', 5.00))
 
-        self.HOMEASSISTANT_ENABLED = os.environ.get('HOMEASSISTANT_ENABLED', False)
+        self.HOMEASSISTANT_ENABLED = os.environ.get('HOMEASSISTANT_ENABLED', 'false').lower() == 'true'
         self.HOMEASSISTANT_ID = os.environ.get('HOMEASSISTANT_ID', 'TeoTopf')
         self.HOMEASSISTANT_MQTT_SERVER = os.environ.get('HOMEASSISTANT_MQTT_SERVER', 'undefined')
         self.HOMEASSISTANT_MQTT_USER = os.environ.get('HOMEASSISTANT_MQTT_USER', 'undefined')


### PR DESCRIPTION
## Summary
- ensure HOMEASSISTANT_ENABLED environment variable is converted to a boolean

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a627e62dc832e9513b0f43c59d9d7