### PR TITLE
Allow SensorManager to create an I2C bus when not provided

### DIFF
--- a/Application/sensormanager.py
+++ b/Application/sensormanager.py
@@ -18,8 +18,10 @@ from .sensorbh1750 import SensorBH1750
 from .sensorbmp280 import SensorBMP280
 
 class SensorManager:
-    def __init__(self, i2c_bus = busio.I2C(board.SCL, board.SDA), bmp280_address=0x76, bh1750_address=0x23, ads1x15_address=0x48):
+    def __init__(self, i2c_bus=None, bmp280_address=0x76, bh1750_address=0x23, ads1x15_address=0x48):
         # Create a single I2C bus instance
+        if i2c_bus is None:
+            i2c_bus = busio.I2C(board.SCL, board.SDA)
         self._i2c_bus = i2c_bus
 
         # Initialize list for manager-specific callbacks


### PR DESCRIPTION
## Summary
- Allow `SensorManager` to accept a missing `i2c_bus` and create one using board pins.

## Testing
- `pyflakes Application`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a63f1b16c832e9afd60f2ffc5852b