### PR TITLE
Expose current emotion property

### DIFF
--- a/Application/app.py
+++ b/Application/app.py
@@ -105,7 +105,7 @@ class Application:
 
         self._log.info(f"{temperature_str} / {pressure_str} / {light_intensity_str}")
         self._log.info(f"A/D: {ads1x15_values_str}")
-        self._log.info(f"Display Emotion: {self.display_manager._current_emotion}")
+        self._log.info(f"Display Emotion: {self.display_manager.current_emotion}")
 
     ###################################################################################################################
     def show_random_emotions(self):

--- a/Application/displaymanager.py
+++ b/Application/displaymanager.py
@@ -151,6 +151,11 @@ class DisplayManager(threading.Thread):
         else:
             raise ValueError(f"Invalid emotion: {emotion}. Valid emotions are: {self._VALID_EMOTIONS}")
 
+    @property
+    def current_emotion(self):
+        """Return the emotion currently being displayed."""
+        return self._current_emotion
+
     def run(self):
         self._is_running = True
         self._backlight.value = True  # Turn on the backlight when starting


### PR DESCRIPTION
## Summary
- expose display manager's current emotion through a property
- use new current_emotion accessor when logging

## Testing
- `python -m py_compile Application/displaymanager.py Application/app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a63ce5504832ebc883b11b22682a3