### PR TITLE
Add sensor stop events and manager shutdown handling

### DIFF
--- a/Application/app.py
+++ b/Application/app.py
@@ -60,6 +60,9 @@ class Application:
         if self._app_thread is not None:
             self._app_thread.join()
 
+        # Stop sensors
+        self.sensor_manager.stop()
+
         # Stop Display Manager
         self.display_manager.stop()
 

--- a/Application/sensorads1x15.py
+++ b/Application/sensorads1x15.py
@@ -32,6 +32,9 @@ class SensorADS1x15:
         # Set up list for callback functions
         self.callbacks = []
 
+        # Event to control polling thread
+        self._stop_event = threading.Event()
+
         self.polling_thread = threading.Thread(target=self._poll_sensor)
         self.polling_thread.daemon = True
         self.polling_thread.start()
@@ -50,8 +53,13 @@ class SensorADS1x15:
 
         return current_values
 
+    def stop(self):
+        self._stop_event.set()
+        if self.polling_thread.is_alive():
+            self.polling_thread.join()
+
     def _poll_sensor(self):
-        while True:
+        while not self._stop_event.is_set():
             # Get current readings
             current_values = [channel.value for channel in self.channels]
 

--- a/Application/sensorbh1750.py
+++ b/Application/sensorbh1750.py
@@ -27,6 +27,9 @@ class SensorBH1750:
         # Set up list for callback functions
         self.callbacks = []
 
+        # Event to control polling thread
+        self._stop_event = threading.Event()
+
         self.polling_thread = threading.Thread(target=self._poll_sensor)
         self.polling_thread.daemon = True
         self.polling_thread.start()
@@ -44,8 +47,13 @@ class SensorBH1750:
 
         return current_light_intensity
 
+    def stop(self):
+        self._stop_event.set()
+        if self.polling_thread.is_alive():
+            self.polling_thread.join()
+
     def _poll_sensor(self):
-        while True:
+        while not self._stop_event.is_set():
             # Get current reading
             current_light_intensity = round(self.bh1750.lux, 2)
 

--- a/Application/sensorbmp280.py
+++ b/Application/sensorbmp280.py
@@ -28,6 +28,9 @@ class SensorBMP280:
         # Set up list for callback functions
         self.callbacks = []
 
+        # Event to control polling thread
+        self._stop_event = threading.Event()
+
         self.polling_thread = threading.Thread(target=self._poll_sensor)
         self.polling_thread.daemon = True
         self.polling_thread.start()
@@ -47,8 +50,13 @@ class SensorBMP280:
 
         return current_temperature, current_pressure
 
+    def stop(self):
+        self._stop_event.set()
+        if self.polling_thread.is_alive():
+            self.polling_thread.join()
+
     def _poll_sensor(self):
-        while True:
+        while not self._stop_event.is_set():
             # Get current readings
             current_temperature = round(self.bmp280.temperature, 2)
             current_pressure = round(self.bmp280.pressure, 2)

--- a/Application/sensormanager.py
+++ b/Application/sensormanager.py
@@ -83,3 +83,8 @@ class SensorManager:
 
         # Immediately call the new callback with the current sensor values
         callback(self)
+
+    def stop(self):
+        self._sensor_bmp280.stop()
+        self._sensor_bh1750.stop()
+        self._sensor_ads1x15.stop()


### PR DESCRIPTION
## Summary
- add `stop` methods with stop events for `SensorBMP280`, `SensorBH1750`, and `SensorADS1x15`
- ensure `SensorManager` and `Application` stop sensor threads during shutdown

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`
- `flake8` *(fails: E501 line too long, F401 imported but unused, and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689a63f5bb48832e946204fe7230d34a