### PR TITLE
Add default INFO fallback for unknown log levels

### DIFF
--- a/Application/configuration.py
+++ b/Application/configuration.py
@@ -72,7 +72,12 @@ class Configuration:
     ###################################################################################################################
 
     @staticmethod
-    def loglevel_from_string(log_level: str):
-        return logging.getLevelName(log_level)
+    def loglevel_from_string(log_level: str, default: int = logging.INFO) -> int:
+        """Return the logging level for ``log_level``.
+
+        If the provided level name is unknown, ``default`` (``logging.INFO`` by
+        default) is returned instead.
+        """
+        return logging._nameToLevel.get(log_level.upper(), default)
 
 #######################################################################################################################

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,0 +1,19 @@
+import logging
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from Application.configuration import Configuration
+
+
+class TestConfiguration(unittest.TestCase):
+    def test_log_level_invalid_defaults_to_info(self):
+        self.assertEqual(
+            Configuration.loglevel_from_string("invalid"),
+            logging.INFO,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace `logging.getLevelName` with `_nameToLevel` lookup in `Configuration.loglevel_from_string`
- Document default INFO fallback for unknown log level names
- Test that invalid log level strings fall back to INFO

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a69ddc568832ebf32bc661493cb8f